### PR TITLE
Fix deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SublimeLinter-erlc
 [![Build Status](https://travis-ci.org/SublimeLinter/SublimeLinter-erlc.svg?branch=master)](https://travis-ci.org/SublimeLinter/SublimeLinter-erlc)
 
 
-This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) provides an interface to [erlc](http://erlang.org/doc/man/erlc.html). It will be used with files that have the `Erlang` or `Erlang Improved` syntax.
+This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) provides an interface to [erlc](http://erlang.org/doc/man/erlc.html). It will be used with files that have the `Erlang` syntax.
 
 ## Installation
 SublimeLinter must be installed in order to use this plugin. 

--- a/linter.py
+++ b/linter.py
@@ -15,12 +15,6 @@ from SublimeLinter.lint import Linter, util
 class Erlc(Linter):
     """Provides an interface to erlc."""
 
-    syntax = (
-        "erlang",
-        "erlang improved"
-    )
-
-    executable = "erlc"
     tempfile_suffix = "-"
 
     # ERROR FORMAT # <file>:<line>: [Warning:|] <message> #
@@ -33,6 +27,7 @@ class Erlc(Linter):
     error_stream = util.STREAM_STDOUT
 
     defaults = {
+        "selector": "source.erlang",
         "include_dirs": []
     }
 
@@ -44,7 +39,7 @@ class Erlc(Linter):
         """
         command = ['erlc', '-W']
 
-        settings = self.get_view_settings()
+        settings = self.settings
         dirs = settings.get('include_dirs', [])
         pa_dirs = settings.get('pa_dirs', [])
         pz_dirs = settings.get('pz_dirs', [])


### PR DESCRIPTION
* Switch from cls.syntax -> cls.defaults.selector
* Remove unneeded cls.executable
* Removes references to Erlang improved syntax