### PR TITLE
Fix badge, change url in install.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ SublimeLinter-erlc
 ==========================
 
 
-[![Build Status](https://travis-ci.org/SublimeLinter/SublimeLinter-erlc.svg?branch=master)](https://travis-ci.org/SublimeLinter/SublimeLinter-erlc)
+[![Build Status](https://travis-ci.com/SublimeLinter/SublimeLinter-erlc.svg?branch=master)](https://travis-ci.com/SublimeLinter/SublimeLinter-erlc)
 
 
 This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) provides an interface to [erlc](http://erlang.org/doc/man/erlc.html). It will be used with files that have the `Erlang` or `Erlang Improved` syntax.

--- a/messages/install.txt
+++ b/messages/install.txt
@@ -7,4 +7,4 @@ This linter plugin for SublimeLinter provides an interface to erlc.
 Before this plugin will activate, you *must*
 follow the installation instructions here:
 
-https://github.com/teh-cmc/SublimeLinter-contrib-erlc
+https://github.com/SublimeLinter/SublimeLinter-erlc


### PR DESCRIPTION
I noticed that the badge wasn't rendering correctly, and
the URL in the `install.txt` file pointed to the old repo.
Fixes?