### PR TITLE
Add new selector, remove old.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -15,11 +15,6 @@ from SublimeLinter.lint import Linter, util
 class Erlc(Linter):
     """Provides an interface to erlc."""
 
-    syntax = (
-        "erlang",
-        "erlang improved"
-    )
-
     executable = "erlc"
     tempfile_suffix = "-"
 
@@ -33,7 +28,8 @@ class Erlc(Linter):
     error_stream = util.STREAM_STDOUT
 
     defaults = {
-        "include_dirs": []
+        "include_dirs": [],
+        "selector": "source.erlang"
     }
 
     def cmd(self):


### PR DESCRIPTION
Getting back to the start of this saga ([link to the start of this saga](https://github.com/SublimeLinter/SublimeLinter/issues/1643)), I think the same issues that were happening in the `SublimeLint-contrib-erlc` are happening with this linter. Specifically:

```
SublimeLinter: ERROR:
=====================

erlc: Defining 'cls.syntax' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.


SublimeLinter: ERROR:
=====================

erlc disabled. 'selector' is mandatory in 'cls.defaults'.
 See http://www.sublimelinter.com/en/stable/linter_settings.html#selector
```

I think this PR fixes both the warning ([remove old lines 18-21](https://github.com/distortedsignal/SublimeLinter-erlc/blob/f7f16af4702ad77c0be47d3692221699d551144d/linter.py#L18-L21)) and the error that causes the linter to fail to run ([new lines 31-32](https://github.com/distortedsignal/SublimeLinter-erlc/blob/8a2c2b7f1ad494b4d1ff9ca60dd2e709bcd2b4a3/linter.py#L31-L32)).